### PR TITLE
Update ExpiresOn type from time to string

### DIFF
--- a/giftcard.go
+++ b/giftcard.go
@@ -38,10 +38,10 @@ type GiftCard struct {
 	Note           string           `json:"note,omitempty"`
 	TemplateSuffix string           `json:"template_suffix,omitempty"`
 	LastCharacters string           `json:"last_characters,omitempty"`
+	ExpiresOn      string           `json:"expires_on,omitempty"`
 	CreatedAt      *time.Time       `json:"created_at,omitempty"`
 	UpdatedAt      *time.Time       `json:"updated_at,omitempty"`
 	DisabledAt     *time.Time       `json:"disabled_at,omitempty"`
-	ExpiresOn      *time.Time       `json:"expires_on,omitempty"`
 	APIClientID    int64            `json:"api_client_id,omitempty"`
 	OrderID        int64            `json:"order_id,omitempty"`
 	UserID         int64            `json:"user_id,omitempty"`


### PR DESCRIPTION
Since ExpiresOn doesn't come back from Shopify in RFC 3339 format, it's not going to unmarshal correctly when getting a response back from Shopify. We would have to create our own time.Time type and implement the json.Marshaler and json.Unmarshaler interfaces on that type in order for it to work, so it seems much more straightforward to instead have the user modify the string to match the expected format (YYYY-MM-DD).