### PR TITLE
Add masked code to gift card struct

### DIFF
--- a/giftcard.go
+++ b/giftcard.go
@@ -34,6 +34,7 @@ type GiftCard struct {
 	InitialValue   *decimal.Decimal `json:"initial_value,omitempty"`
 	Balance        *decimal.Decimal `json:"balance,omitempty"`
 	Code           string           `json:"code,omitempty"`
+	MaskedCode     string           `json:"masked_code,omitempty"`
 	Currency       string           `json:"currency,omitempty"`
 	Note           string           `json:"note,omitempty"`
 	TemplateSuffix string           `json:"template_suffix,omitempty"`

--- a/pricerule_test.go
+++ b/pricerule_test.go
@@ -96,7 +96,7 @@ func TestPriceRuleCreate(t *testing.T) {
 		PrerequisiteQuantityRange:              nil,
 		PrerequisiteShippingPriceRange:         nil,
 		PrerequisiteToEntitlementQuantityRatio: prerequisiteToEntitlementQuantityRatio,
-		Title: "SUMMERSALE10OFF",
+		Title:                                  "SUMMERSALE10OFF",
 	}
 
 	returnedPriceRule, err := client.PriceRule.Create(priceRule)


### PR DESCRIPTION
Adds `masked_code` field to Gift Card struct. Will be used by fulfillment.