### PR TITLE
Revert all throttling and retry logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 *.swp
 coverage.*
 .vscode
-.idea

--- a/goshopify.go
+++ b/goshopify.go
@@ -241,16 +241,12 @@ func (c *Client) Do(req *http.Request, v interface{}) error {
 	}
 
 	if callLimit, ok := resp.Header[callLimitHeader]; ok {
-		logMessage := fmt.Sprintf("%s: %s", callLimitHeader, callLimit[0])
 		// Extract the current bucket capacity from the call limit response header
 		bucketCapacity, err = strconv.Atoi(strings.Split(callLimit[0], "/")[0])
 		if err != nil {
-			logMessage = "Unable to parse the call limit header. " + logMessage
-			// set bucket capacity to the threshold + 1 to throttle requests until call limit header can be parsed
-			bucketCapacity = c.app.BucketThreshold + 1
+			return err
 		}
-
-		c.log.Info(logMessage)
+		c.log.Info("%s: %s", callLimitHeader, callLimit[0])
 	}
 
 	if v != nil {

--- a/goshopify.go
+++ b/goshopify.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/eapache/go-resiliency/retrier"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -228,7 +227,6 @@ func (c *Client) WithLogger(l Logger) *Client {
 func (c *Client) Do(req *http.Request, v interface{}) error {
 	// Self-throttle if bucket capacity is specified and exceeds threshold
 	if c.app.BucketThreshold > 0 && bucketCapacity > c.app.BucketThreshold {
-		c.log.Warn("sleep due to heavy Shopify API traffic for time=%s.", c.app.HeavyLoadDelay)
 		time.Sleep(c.app.HeavyLoadDelay)
 	}
 	resp, err := c.Client.Do(req)
@@ -247,7 +245,7 @@ func (c *Client) Do(req *http.Request, v interface{}) error {
 		// Extract the current bucket capacity from the call limit response header
 		bucketCapacity, err = strconv.Atoi(strings.Split(callLimit[0], "/")[0])
 		if err != nil {
-			logMessage = "Unable to parse the call limit header: " + logMessage
+			logMessage = "Unable to parse the call limit header. " + logMessage
 			// set bucket capacity to the threshold + 1 to throttle requests until call limit header can be parsed
 			bucketCapacity = c.app.BucketThreshold + 1
 		}
@@ -264,40 +262,6 @@ func (c *Client) Do(req *http.Request, v interface{}) error {
 	}
 
 	return nil
-}
-
-var errorClassifier ErrorClassifier
-
-type ErrorClassifier struct{}
-
-func (s ErrorClassifier) Classify(err error) retrier.Action {
-	if err == nil {
-		return retrier.Succeed
-	}
-
-	switch err.(type) {
-	case RateLimitError:
-		return retrier.Retry
-
-	default:
-		return retrier.Fail
-	}
-}
-
-func (c *Client) DoWithRetry(req *http.Request, v interface{}) (err error) {
-	// exponential retry 5 times with a maximum of 15 seconds delay
-	r := retrier.New(retrier.ExponentialBackoff(4, 1*time.Second), errorClassifier)
-	numRetry := 0
-	err = r.Run(func() error {
-		err := c.Do(req, v)
-		numRetry += 1
-		if err != nil {
-			c.log.Warn("error occurred calling Shopify: %v; numCalled=%d; may retry", err, numRetry)
-		}
-		return err
-	})
-
-	return err
 }
 
 func wrapSpecificError(r *http.Response, err ResponseError) error {
@@ -445,7 +409,7 @@ func (c *Client) CreateAndDo(method, path string, data, options, resource interf
 		return err
 	}
 
-	err = c.DoWithRetry(req, resource)
+	err = c.Do(req, resource)
 	if err != nil {
 		return err
 	}

--- a/goshopify.go
+++ b/goshopify.go
@@ -18,22 +18,19 @@ import (
 )
 
 const (
-	UserAgent       = "goshopify/1.0.0"
+	UserAgent = "goshopify/1.0.0"
+
 	callLimitHeader = "X-Shopify-Shop-Api-Call-Limit"
 )
-
-var bucketCapacity = 0
 
 // App represents basic app settings such as Api key, secret, scope, and redirect url.
 // See oauth.go for OAuth related helper functions.
 type App struct {
-	ApiKey          string
-	ApiSecret       string
-	RedirectUrl     string
-	Scope           string
-	Password        string
-	BucketThreshold int           // when bucket capacity reaches threshold delay next request
-	HeavyLoadDelay  time.Duration // delay between requests under heavy load
+	ApiKey      string
+	ApiSecret   string
+	RedirectUrl string
+	Scope       string
+	Password    string
 }
 
 // Client manages communication with the Shopify API.
@@ -225,10 +222,6 @@ func (c *Client) WithLogger(l Logger) *Client {
 // response. It does not make much sense to call Do without a prepared
 // interface instance.
 func (c *Client) Do(req *http.Request, v interface{}) error {
-	// Self-throttle if bucket capacity is specified and exceeds threshold
-	if c.app.BucketThreshold > 0 && bucketCapacity > c.app.BucketThreshold {
-		time.Sleep(c.app.HeavyLoadDelay)
-	}
 	resp, err := c.Client.Do(req)
 	if err != nil {
 		return err
@@ -241,11 +234,6 @@ func (c *Client) Do(req *http.Request, v interface{}) error {
 	}
 
 	if callLimit, ok := resp.Header[callLimitHeader]; ok {
-		// Extract the current bucket capacity from the call limit response header
-		bucketCapacity, err = strconv.Atoi(strings.Split(callLimit[0], "/")[0])
-		if err != nil {
-			return err
-		}
 		c.log.Info("%s: %s", callLimitHeader, callLimit[0])
 	}
 

--- a/logger.go
+++ b/logger.go
@@ -6,16 +6,11 @@ import "fmt"
 // the default logging.
 type Logger interface {
 	Info(format string, args ...interface{})
-	Warn(format string, args ...interface{})
 }
 
 // defaultLogger is a very naive logger that just prints to standard output.
 type defaultLogger struct{}
 
-func (l defaultLogger) Info(format string, args ...interface{}) {
-	fmt.Printf("[INFO] "+format+"\n", args...)
-}
-
-func (l defaultLogger) Warn(format string, args ...interface{}) {
-	fmt.Printf("[WARN] "+format+"\n", args...)
+func (l *defaultLogger) Info(format string, args ...interface{}) {
+	fmt.Printf(format+"\n", args...)
 }

--- a/oauth.go
+++ b/oauth.go
@@ -48,7 +48,7 @@ func (app App) GetAccessToken(shopName string, code string) (string, error) {
 	req, err := client.NewRequest("POST", "admin/oauth/access_token", data, nil)
 
 	token := new(Token)
-	err = client.DoWithRetry(req, token)
+	err = client.Do(req, token)
 	return token.Token, err
 }
 


### PR DESCRIPTION
Reverts #28, #27, and #26

There was a race condition in this code. We don't really need this extra logic anymore. We can just get rid of it and the race condition. This also brings us closer to upstream to allow us to merge from there more easily.

This removes retry logic that was only used when rate limit errors occurred, however we have no calls in the logs that suggest we hit this code.